### PR TITLE
Migrated to multistage build to reduce final image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,37 @@
-FROM alpine
+FROM alpine as base
+
+FROM base as builder
 ENV AKAMAI_CLI_HOME=/cli GOROOT=/usr/lib/go GOPATH=/go
-RUN mkdir -p /cli/.akamai-cli && mkdir /pipeline
+RUN mkdir -p /cli/.akamai-cli
 RUN apk add --no-cache git bash python2 python2-dev py2-pip python3 python3-dev npm wget jq openssl openssl-dev curl nodejs build-base libffi libffi-dev vim nano util-linux go dep tree bind-tools 
-RUN wget -q `curl -s https://api.github.com/repos/akamai/cli/releases/latest | jq .assets[].browser_download_url | grep linuxamd64 | grep -v sig | sed s/\"//g`
-RUN mv akamai-*-linuxamd64 /usr/local/bin/akamai && chmod +x /usr/local/bin/akamai 
-RUN go get github.com/akamai/cli && cd $GOPATH/src/github.com/akamai/cli && dep ensure && go build -o /usr/local/bin/akamai && chmod +x /usr/local/bin/akamai 
+RUN go get github.com/akamai/cli && cd $GOPATH/src/github.com/akamai/cli && dep ensure && go build -o /usr/local/bin/akamai
+# RUN cd $GOPATH/src/github.com/akamai && \
+#     git clone https://github.com/akamai/terraform-provider-akamai.git && \
+#     cd $GOPATH/src/github.com/akamai/terraform-provider-akamai && \
+#     make dep-install && \
+#     make build
 RUN pip install --upgrade pip
 RUN curl -s https://developer.akamai.com/cli/package-list.json | jq .packages[].name | sed s/\"//g | xargs akamai install --force 
 RUN akamai install --force property-manager
 RUN akamai install cli-api-gateway 
+WORKDIR /wheels
+RUN pip install wheel
+RUN pip wheel httpie httpie-edgegrid 
+
+FROM base
+ENV AKAMAI_CLI_HOME=/cli GOROOT=/usr/lib/go GOPATH=/go
+RUN apk add --no-cache git bash python2 py2-pip python3 npm wget jq openssl curl nodejs libffi vim nano util-linux tree bind-tools 
+
+COPY --from=builder /wheels /wheels
+RUN pip install --upgrade pip && \
+    pip install -f /wheels httpie httpie-edgegrid && \
+    rm -rf /wheels && \
+    rm -rf /root/.cache/pip/*
+
+COPY --from=builder /cli /cli
+COPY --from=builder /usr/local/bin/akamai /usr/local/bin/akamai
+#COPY --from=builder /go/bin/terraform-provider-akamai /root/.terraform.d/plugins/
+
 RUN echo 'eval "$(/usr/local/bin/akamai --bash)"' >> /root/.bashrc 
 RUN echo "[cli]" > /cli/.akamai-cli/config && \
     echo "cache-path            = /cli/.akamai-cli/cache" >> /cli/.akamai-cli/config && \
@@ -31,7 +54,6 @@ RUN echo '         ___    __                         _    ' >  /root/.motd && \
     echo '================================================' >> /root/.motd
 RUN echo "cat /root/.motd" >> /root/.bashrc 
 RUN echo "PS1='Akamai Developer [\w]$ '" >> /root/.bashrc 
-RUN pip install httpie-edgegrid 
 RUN mkdir /root/.httpie 
 RUN echo '{' >> /root/.httpie/config.json && \
     echo '"__meta__": {' >> /root/.httpie/config.json && \
@@ -41,6 +63,14 @@ RUN echo '{' >> /root/.httpie/config.json && \
     echo '"default_options": ["--timeout=300","--style=autumn"], ' >> /root/.httpie/config.json && \
     echo '"implicit_content_type": "json"' >> /root/.httpie/config.json && \
     echo '}' >> /root/.httpie/config.json
+
+# ENV TERRAFORM_VERSION=0.11.8 \
+#     TERRAFORM_SHA256SUM=84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7
+# RUN curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+#     echo "${TERRAFORM_SHA256SUM} *terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
+#     sha256sum -c terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
+#     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin && \
+#     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS
 
 VOLUME /root
 VOLUME /pipeline


### PR DESCRIPTION
First stage is only responsible to build binaries which are later used
in the second stage to build final image.
Splitting up this work allows to install build dependencies like
libraries, compilers, etc.. only in the first stage. As a result a lot
of space is saved in the final image.

Python tools like httpie+edgegrid use Python wheel to transport binary
packages to the final image.

Go tools don't require any source deps therefore only binaries are
copied to the final image.

CLI modules are not optimized and copied along with sources to the final
image (this may be improved in future).

The above allowed to drop from 1.89GB to 988MB of the image size.

Terraform provider as well as the core binary are commented out to
deliver same subset of tools like original Dockerfile.

Note: Since build tools are not available in the final image it's not
possible to upgrade or install something new. Essentially, this should
not be a problem since where new versions of CLI/tools are release,
a new docker image should be created.